### PR TITLE
Add support for any length file names reporting coverage for

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,11 +21,11 @@ const getCommandStdoutText = async (command: string) => {
 }
 
 const getCoverageOutputTextForCommand = async (command: string) => {
+  const regex = / *File *| *% Stmts *| *% Branch *| % Funcs | *Lines */
+
   const text = await getCommandStdoutText(command)
 
-  const reportStartsAt = text.indexOf(
-    "File      | % Stmts | % Branch | % Funcs | % Lines"
-  )
+  const reportStartsAt = text.search(regex)
 
   return text.slice(reportStartsAt)
 }


### PR DESCRIPTION
Switch from fixed string match to regex match for first line of report to add support for arbitrary file name lengths.